### PR TITLE
[Feat.] Criação do Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM python:3.11-slim AS python-base
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    \
+
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    \
+
+    POETRY_VERSION=1.0.3 \
+    POETRY_HOME="/opt/poetry" \
+    POETRY_VIRTUALENVS_IN_PROJECT=true \
+    POETRY_NO_INTERACTION=1 \
+    \
+
+    PYSETUP_PATH="/opt/pysetup" \
+    VENV_PATH="/opt/pysetup/.venv"
+
+ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl \
+        build-essential
+
+RUN pip install poetry poetry init
+
+RUN apt-get update \
+    && apt-get -y install libpq-dev gcc \
+    && pip install psycopg2
+
+WORKDIR $PYSETUP_PATH
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install
+
+WORKDIR /app
+
+COPY . /app/
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
Criação de uma imagem da aplicação, pronta para ser rodada à partir de qualquer ambiente, utilizando a porta 8000 como padrão.

Caso haja necessidade de trocar a porta, basta alterar as linhas **44** e **46** do `Dockerfile`, e executar o comando `docker build -t <nome_da_iamgem:versão> .`;

![image](https://github.com/user-attachments/assets/17ef2601-a2f2-4265-8d40-9bad0174adeb)
